### PR TITLE
Migrate tests to purescript-assert

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,6 @@
   },
   "devDependencies": {
     "purescript-console": "^4.2.0",
-    "purescript-test-unit": "^15.0.0"
+    "purescript-assert": "^4.1.0"
   }
 }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -11,9 +11,7 @@ import Data.Number.Approximate (Fraction(..), Tolerance(..), eqRelative,
 
 import Effect (Effect)
 
-import Test.Unit (suite, test)
-import Test.Unit.Assert (assert, assertFalse, equal)
-import Test.Unit.Main (runTest)
+import Test.Assert (assertTrue', assertFalse', assertEqual)
 
 
 -- | Comparison up to 10% relative error.
@@ -28,182 +26,232 @@ eqAbsolute' = eqAbsolute (Tolerance 0.1)
 
 infix 1 eqAbsolute' as =~=
 
-main ∷ Effect Unit
-main = runTest do
+main :: Effect Unit
+main = do
 
 
-  suite "Data.Number.fromString" do
-    test "valid number string" do
-      assert "integer strings are coerced" $
-        fromMaybe false $ map (_ == 123.0) $ fromString "123"
+  -- suite "Data.Number.fromString" do
+    -- test "valid number string" do
+  assertTrue' "integer strings are coerced" $
+    fromMaybe false $ map (_ == 123.0) $ fromString "123"
 
-      assert "decimals are coerced" $
-        fromMaybe false $ map (_ == 12.34) $ fromString "12.34"
+  assertTrue' "decimals are coerced" $
+    fromMaybe false $ map (_ == 12.34) $ fromString "12.34"
 
-      assert "exponents are coerced" $
-        fromMaybe false $ map (_ == 1e4) $ fromString "1e4"
+  assertTrue' "exponents are coerced" $
+    fromMaybe false $ map (_ == 1e4) $ fromString "1e4"
 
-      assert "decimals exponents are coerced" $
-        fromMaybe false $ map (_ == 1.2e4) $ fromString "1.2e4"
+  assertTrue' "decimals exponents are coerced" $
+    fromMaybe false $ map (_ == 1.2e4) $ fromString "1.2e4"
 
-    test "invalid number string" do
-      assert "invalid strings are not coerced" $
-        Nothing == fromString "bad string"
+    -- test "invalid number string" do
+  assertTrue' "invalid strings are not coerced" $
+    Nothing == fromString "bad string"
 
-    test "too large numbers" do
-      assert "too large numbers are not coerced" $
-        Nothing == fromString "1e1000"
+    -- test "too large numbers" do
+  assertTrue' "too large numbers are not coerced" $
+    Nothing == fromString "1e1000"
 
+  -- suite "Data.Number.isNaN" do
+    -- test "Check for NaN" do
+  assertTrue' "NaN is not a number" $ isNaN nan
+  assertFalse' "infinity is a number" $ isNaN infinity
+  assertFalse' "1.0 is a number" $ isNaN 1.0
 
-  suite "Data.Number.isNaN" do
-    test "Check for NaN" do
-      assert "NaN is not a number" $ isNaN nan
-      assertFalse "infinity is a number" $ isNaN infinity
-      assertFalse "1.0 is a number" $ isNaN 1.0
-
-
-  suite "Data.Number.isFinite" do
-    test "Check for infinity" do
-      assert "1.0e100 is a finite number" $ isFinite 1.0e100
-      assertFalse "detect positive infinity" $ isFinite infinity
-      assertFalse "detect negative infinity" $ isFinite (-infinity)
-      assertFalse "detect NaN" $ isFinite nan
-
+  -- suite "Data.Number.isFinite" do
+    -- test "Check for infinity" do
+  assertTrue' "1.0e100 is a finite number" $ isFinite 1.0e100
+  assertFalse' "detect positive infinity" $ isFinite infinity
+  assertFalse' "detect negative infinity" $ isFinite (-infinity)
+  assertFalse' "detect NaN" $ isFinite nan
 
   let pi = 3.14159
-  suite "Data.Format.toStringWith" do
+  -- suite "Data.Format.toStringWith" do
 
-    test "precision" do
-      equal "3.14"    (toStringWith (precision 3) pi)
-      equal "3.1416"  (toStringWith (precision 5) pi)
-      equal "3"       (toStringWith (precision 1) pi)
-      equal "3"       (toStringWith (precision (-3)) pi)
-      equal "3.14"    (toStringWith (precision 3) pi)
-      equal "1.2e+3"  (toStringWith (precision 2) 1234.5)
+    -- test "precision" do
+  assertEqual
+    { expected: "3.14"
+    , actual: toStringWith (precision 3) pi
+    }
+  assertEqual
+    { expected: "3.1416"
+    , actual: toStringWith (precision 5) pi
+    }
+  assertEqual
+    { expected: "3"
+    , actual: toStringWith (precision 1) pi
+    }
+  assertEqual
+    { expected: "3"
+    , actual: toStringWith (precision (-3)) pi
+    }
+  assertEqual
+    { expected: "3.14"
+    , actual: toStringWith (precision 3) pi
+    }
+  assertEqual
+    { expected: "1.2e+3"
+    , actual: toStringWith (precision 2) 1234.5
+    }
 
-    test "fixed" do
-      equal "3.14"    (toStringWith (fixed 2) pi)
-      equal "3.1416"  (toStringWith (fixed 4) pi)
-      equal "3"       (toStringWith (precision 0) pi)
-      equal "3"       (toStringWith (precision (-3)) pi)
-      equal "1234.5"  (toStringWith (fixed 1) 1234.5)
+    -- test "fixed" do
+  assertEqual
+    { expected: "3.14"
+    , actual: toStringWith (fixed 2) pi
+    }
+  assertEqual
+    { expected: "3.1416"
+    , actual: toStringWith (fixed 4) pi
+    }
+  assertEqual
+    { expected: "3"
+    , actual: toStringWith (precision 0) pi
+    }
+  assertEqual
+    { expected: "3"
+    , actual: toStringWith (precision (-3)) pi
+    }
+  assertEqual
+    { expected: "1234.5"
+    , actual: toStringWith (fixed 1) 1234.5
+    }
 
-    test "exponential" do
-      equal "3e+0"    (toStringWith (exponential 0) pi)
-      equal "3.14e+0" (toStringWith (exponential 2) pi)
-      equal "3.14e+2" (toStringWith (exponential 2) (100.0 * pi))
-      equal "1.2e+3"  (toStringWith (exponential 1) 1234.5)
+    -- test "exponential" do
+  assertEqual
+    { expected: "3e+0"
+    , actual: toStringWith (exponential 0) pi
+    }
+  assertEqual
+    { expected: "3.14e+0"
+    , actual: toStringWith (exponential 2) pi
+    }
+  assertEqual
+    { expected: "3.14e+2"
+    , actual: toStringWith (exponential 2) (100.0 * pi)
+    }
+  assertEqual
+    { expected: "1.2e+3"
+    , actual: toStringWith (exponential 1) 1234.5
+    }
 
-  suite "Data.Format.toString" do
+  -- suite "Data.Format.toString" do
 
-    test "toString" do
-      equal "3.14159" (toString pi)
-      equal "10" (toString 10.0)
+    -- test "toString" do
+  assertEqual
+    { expected: "3.14159"
+    , actual: toString pi
+    }
 
-  suite "Data.Number.Approximate.eqRelative" do
-    test "eqRelative" do
-      assert "should return true for differences smaller 10%" $
-        10.0 ~= 10.9
+  assertEqual
+    { expected: "10"
+    , actual: toString 10.0
+    }
 
-      assert "should return true for differences smaller 10%" $
-        10.0 ~= 9.2
+  -- suite "Data.Number.Approximate.eqRelative" do
+    -- test "eqRelative" do
+  assertTrue' "should return true for differences smaller 10%" $
+    10.0 ~= 10.9
 
-      assertFalse "should return false for differences larger than 10%" $
-        10.0 ~= 11.1
+  assertTrue' "should return true for differences smaller 10%" $
+    10.0 ~= 9.2
 
-      assertFalse "should return false for differences larger than 10%" $
-        10.0 ~= 9.01
+  assertFalse' "should return false for differences larger than 10%" $
+    10.0 ~= 11.1
 
-    test "eqRelative (large numbers)" do
-      assert "should return true for differences smaller 10%" $
-        100000000000.0 ~= 109000000000.0
+  assertFalse' "should return false for differences larger than 10%" $
+    10.0 ~= 9.01
 
-      assert "should return true for differences smaller 10%" $
-        100000000000.0 ~= 92000000000.0
+    -- test "eqRelative (large numbers)" do
+  assertTrue' "should return true for differences smaller 10%" $
+    100000000000.0 ~= 109000000000.0
 
-      assertFalse "should return false for differences larger than 10%" $
-        100000000000.0 ~= 111000000000.0
+  assertTrue' "should return true for differences smaller 10%" $
+    100000000000.0 ~= 92000000000.0
 
-      assertFalse "should return false for differences larger than 10%" $
-        100000000000.0 ~= 90000000000.0
+  assertFalse' "should return false for differences larger than 10%" $
+    100000000000.0 ~= 111000000000.0
 
-    test "eqRelative (small numbers)" do
-      assert "should return true for differences smaller 10%" $
-        0.000000000001 ~= 0.00000000000109
+  assertFalse' "should return false for differences larger than 10%" $
+    100000000000.0 ~= 90000000000.0
 
-      assert "should return true for differences smaller 10%" $
-        0.000000000001 ~= 0.00000000000092
+    -- test "eqRelative (small numbers)" do
+  assertTrue' "should return true for differences smaller 10%" $
+    0.000000000001 ~= 0.00000000000109
 
-      assertFalse "should return false for differences larger than 10%" $
-        0.000000000001 ~= 0.00000000000111
+  assertTrue' "should return true for differences smaller 10%" $
+    0.000000000001 ~= 0.00000000000092
 
-      assertFalse "should return false for differences larger than 10%" $
-        0.000000000001 ~= 0.0000000000009
+  assertFalse' "should return false for differences larger than 10%" $
+    0.000000000001 ~= 0.00000000000111
 
-    test "eqRelative (negative numbers)" do
-      assert "should return true for differences smaller 10%" $
-        -10.0 ~= -10.9
+      -- assertFalse
+  assertFalse' "should return false for differences larger than 10%" $
+    0.000000000001 ~= 0.0000000000009
 
-      assert "should return true for differences smaller 10%" $
-        -10.0 ~= -9.2
+    -- test "eqRelative (negative numbers)" do
+  assertTrue' "should return true for differences smaller 10%" $
+    -10.0 ~= -10.9
 
-      assertFalse "should return false for differences larger than 10%" $
-        -10.0 ~= -11.1
+  assertTrue' "should return true for differences smaller 10%" $
+    -10.0 ~= -9.2
 
-      assertFalse "should return false for differences larger than 10%" $
-        -10.0 ~= -9.01
+  assertFalse' "should return false for differences larger than 10%" $
+    -10.0 ~= -11.1
 
-    test "eqRelative (close or equal to 0.0)" do
-      assert "should compare against the fraction if left argument is zero" $
-        0.0 ~= 0.0001
+  assertFalse' "should return false for differences larger than 10%" $
+    -10.0 ~= -9.01
 
-      assert "should compare against the fraction if right argument is zero" $
-        0.0001 ~= 0.0
+    -- test "eqRelative (close or equal to 0.0)" do
+  assertTrue' "should compare against the fraction if left argument is zero" $
+    0.0 ~= 0.0001
 
-      assert "should succeed if both arguments are zero" $
-        0.0 ~= 0.0
+  assertTrue' "should compare against the fraction if right argument is zero" $
+    0.0001 ~= 0.0
 
-      assertFalse "should fail if argument is larger than fraction" $
-        0.0 ~= 0.11
+  assertTrue' "should succeed if both arguments are zero" $
+    0.0 ~= 0.0
 
-      assertFalse "should fail if other argument is not exactly zero" $
-        1.0e-100 ~= 0.1
+  assertFalse' "should fail if argument is larger than fraction" $
+    0.0 ~= 0.11
 
-    test "eqRelative (fraction = 0.0)" do
-      assert "should succeed if numbers are exactly equal" $
-        eqRelative (Fraction 0.0) 3.14 3.14
+  assertFalse' "should fail if other argument is not exactly zero" $
+    1.0e-100 ~= 0.1
 
-      assertFalse "should fail if numbers are not exactly equal" $
-        eqRelative (Fraction 0.0) 3.14 3.14000000000001
+    -- test "eqRelative (fraction = 0.0)" do
+  assertTrue' "should succeed if numbers are exactly equal" $
+    eqRelative (Fraction 0.0) 3.14 3.14
 
-    test "eqRelative (fraction > 1.0)" do
-      assert "should work for 'fractions' larger than one" $
-        eqRelative (Fraction 3.0) 10.0 29.5
+  assertFalse' "should fail if numbers are not exactly equal" $
+    eqRelative (Fraction 0.0) 3.14 3.14000000000001
 
-
-  suite "Data.Number.Approximate.eqApproximate" do
-    test "0.1 + 0.2 ≅ 0.3" do
-      assert "0.1 + 0.2 should be approximately equal to 0.3" $
-        0.1 + 0.2 ≅ 0.3
-
-      assert "0.1 + 0.200001 should not be approximately equal to 0.3" $
-        0.1 + 0.200001 ≇ 0.3
+    -- test "eqRelative (fraction > 1.0)" do
+  assertTrue' "should work for 'fractions' larger than one" $
+    eqRelative (Fraction 3.0) 10.0 29.5
 
 
-  suite "Data.Number.Approximate.eqAbsolute" do
-    test "eqAbsolute" do
-      assert "should succeed for differences smaller than the tolerance" $
-        10.0 =~= 10.09
+  -- suite "Data.Number.Approximate.eqApproximate" do
+  --   test "0.1 + 0.2 ≅ 0.3" do
+  assertTrue' "0.1 + 0.2 should be approximately equal to 0.3" $
+    0.1 + 0.2 ≅ 0.3
 
-      assert "should succeed for differences smaller than the tolerance" $
-        9.91 ~= 10.00
+  assertTrue' "0.1 + 0.200001 should not be approximately equal to 0.3" $
+    0.1 + 0.200001 ≇ 0.3
 
-      assertFalse "should fail for differences larger than the tolerance" $
-        10.0 =~= 10.11
 
-      assertFalse "should fail for differences larger than the tolerance" $
-        9.89 =~= 10.0
+  -- suite "Data.Number.Approximate.eqAbsolute" do
+  --   test "eqAbsolute" do
+  assertTrue' "should succeed for differences smaller than the tolerance" $
+    10.0 =~= 10.09
 
-    test "eqAbsolute (compare against 0)" do
-      assert "should succeed for numbers smaller than the tolerance" $
-        0.0 ~= -0.09
+  assertTrue' "should succeed for differences smaller than the tolerance" $
+    9.91 ~= 10.00
+
+  assertFalse' "should fail for differences larger than the tolerance" $
+    10.0 =~= 10.11
+
+  assertFalse' "should fail for differences larger than the tolerance" $
+    9.89 =~= 10.0
+
+    -- test "eqAbsolute (compare against 0)" do
+  assertTrue' "should succeed for numbers smaller than the tolerance" $
+    0.0 ~= -0.09

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -10,7 +10,7 @@ import Data.Number.Approximate (Fraction(..), Tolerance(..), eqRelative,
                                 eqAbsolute, (≅), (≇))
 
 import Effect (Effect)
-
+import Effect.Console (log)
 import Test.Assert (assertTrue', assertFalse', assertEqual)
 
 
@@ -30,8 +30,8 @@ main :: Effect Unit
 main = do
 
 
-  -- suite "Data.Number.fromString" do
-    -- test "valid number string" do
+  log "Data.Number.fromString"
+  log "\tvalid number string"
   assertTrue' "integer strings are coerced" $
     fromMaybe false $ map (_ == 123.0) $ fromString "123"
 
@@ -44,31 +44,31 @@ main = do
   assertTrue' "decimals exponents are coerced" $
     fromMaybe false $ map (_ == 1.2e4) $ fromString "1.2e4"
 
-    -- test "invalid number string" do
+  log "\tinvalid number string"
   assertTrue' "invalid strings are not coerced" $
     Nothing == fromString "bad string"
 
-    -- test "too large numbers" do
+  log "\ttoo large numbers"
   assertTrue' "too large numbers are not coerced" $
     Nothing == fromString "1e1000"
 
-  -- suite "Data.Number.isNaN" do
-    -- test "Check for NaN" do
+  log "Data.Number.isNaN"
+  log "\tCheck for NaN"
   assertTrue' "NaN is not a number" $ isNaN nan
   assertFalse' "infinity is a number" $ isNaN infinity
   assertFalse' "1.0 is a number" $ isNaN 1.0
 
-  -- suite "Data.Number.isFinite" do
-    -- test "Check for infinity" do
+  log "Data.Number.isFinite"
+  log "\tCheck for infinity"
   assertTrue' "1.0e100 is a finite number" $ isFinite 1.0e100
   assertFalse' "detect positive infinity" $ isFinite infinity
   assertFalse' "detect negative infinity" $ isFinite (-infinity)
   assertFalse' "detect NaN" $ isFinite nan
 
   let pi = 3.14159
-  -- suite "Data.Format.toStringWith" do
+  log "Data.Format.toStringWith"
 
-    -- test "precision" do
+  log "\tprecision"
   assertEqual
     { expected: "3.14"
     , actual: toStringWith (precision 3) pi
@@ -94,7 +94,7 @@ main = do
     , actual: toStringWith (precision 2) 1234.5
     }
 
-    -- test "fixed" do
+  log "\tfixed"
   assertEqual
     { expected: "3.14"
     , actual: toStringWith (fixed 2) pi
@@ -116,7 +116,7 @@ main = do
     , actual: toStringWith (fixed 1) 1234.5
     }
 
-    -- test "exponential" do
+  log "\texponential"
   assertEqual
     { expected: "3e+0"
     , actual: toStringWith (exponential 0) pi
@@ -134,9 +134,9 @@ main = do
     , actual: toStringWith (exponential 1) 1234.5
     }
 
-  -- suite "Data.Format.toString" do
+  log "Data.Format.toString"
 
-    -- test "toString" do
+  log "\ttoString"
   assertEqual
     { expected: "3.14159"
     , actual: toString pi
@@ -147,8 +147,8 @@ main = do
     , actual: toString 10.0
     }
 
-  -- suite "Data.Number.Approximate.eqRelative" do
-    -- test "eqRelative" do
+  log "Data.Number.Approximate.eqRelative"
+  log "\teqRelative"
   assertTrue' "should return true for differences smaller 10%" $
     10.0 ~= 10.9
 
@@ -161,7 +161,7 @@ main = do
   assertFalse' "should return false for differences larger than 10%" $
     10.0 ~= 9.01
 
-    -- test "eqRelative (large numbers)" do
+  log "\teqRelative (large numbers)"
   assertTrue' "should return true for differences smaller 10%" $
     100000000000.0 ~= 109000000000.0
 
@@ -174,7 +174,7 @@ main = do
   assertFalse' "should return false for differences larger than 10%" $
     100000000000.0 ~= 90000000000.0
 
-    -- test "eqRelative (small numbers)" do
+  log "\teqRelative (small numbers)"
   assertTrue' "should return true for differences smaller 10%" $
     0.000000000001 ~= 0.00000000000109
 
@@ -188,7 +188,7 @@ main = do
   assertFalse' "should return false for differences larger than 10%" $
     0.000000000001 ~= 0.0000000000009
 
-    -- test "eqRelative (negative numbers)" do
+  log "\teqRelative (negative numbers)"
   assertTrue' "should return true for differences smaller 10%" $
     -10.0 ~= -10.9
 
@@ -201,7 +201,7 @@ main = do
   assertFalse' "should return false for differences larger than 10%" $
     -10.0 ~= -9.01
 
-    -- test "eqRelative (close or equal to 0.0)" do
+  log "\teqRelative (close or equal to 0.0)"
   assertTrue' "should compare against the fraction if left argument is zero" $
     0.0 ~= 0.0001
 
@@ -217,20 +217,20 @@ main = do
   assertFalse' "should fail if other argument is not exactly zero" $
     1.0e-100 ~= 0.1
 
-    -- test "eqRelative (fraction = 0.0)" do
+  log "\teqRelative (fraction = 0.0)"
   assertTrue' "should succeed if numbers are exactly equal" $
     eqRelative (Fraction 0.0) 3.14 3.14
 
   assertFalse' "should fail if numbers are not exactly equal" $
     eqRelative (Fraction 0.0) 3.14 3.14000000000001
 
-    -- test "eqRelative (fraction > 1.0)" do
+  log "\teqRelative (fraction > 1.0)"
   assertTrue' "should work for 'fractions' larger than one" $
     eqRelative (Fraction 3.0) 10.0 29.5
 
 
-  -- suite "Data.Number.Approximate.eqApproximate" do
-  --   test "0.1 + 0.2 ≅ 0.3" do
+  log "Data.Number.Approximate.eqApproximate"
+  log "\t0.1 + 0.2 ≅ 0.3"
   assertTrue' "0.1 + 0.2 should be approximately equal to 0.3" $
     0.1 + 0.2 ≅ 0.3
 
@@ -238,8 +238,8 @@ main = do
     0.1 + 0.200001 ≇ 0.3
 
 
-  -- suite "Data.Number.Approximate.eqAbsolute" do
-  --   test "eqAbsolute" do
+  log "Data.Number.Approximate.eqAbsolute"
+  log "\teqAbsolute"
   assertTrue' "should succeed for differences smaller than the tolerance" $
     10.0 =~= 10.09
 
@@ -252,6 +252,6 @@ main = do
   assertFalse' "should fail for differences larger than the tolerance" $
     9.89 =~= 10.0
 
-    -- test "eqAbsolute (compare against 0)" do
+  log "\teqAbsolute (compare against 0)"
   assertTrue' "should succeed for numbers smaller than the tolerance" $
     0.0 ~= -0.09


### PR DESCRIPTION
Addresses part of #8 by migrating all tests from `purescript-test-unit` to `purescript-assert`.