### PR TITLE
Math migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: purescript-contrib/setup-purescript@main
-        with:
-          purescript: "0.14.0-rc5"
 
       - uses: actions/setup-node@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ Breaking changes:
 New features:
 - Added various functions and constants from `purescript-math`. Specifically,
 `abs`, `acos`, `asin`, `atan`, `atan2`, `ceil`, `cos`, `exp`, `floor`, `log`,
-`max`, `min`, `pow`, `remainder`, `round`, `sin`, `sqrt`, `tan`, `trunc`, `e`,
-`ln2`, `ln10`, `log10e`, `log2e`, `pi`, `sqrt1_2`, `sqrt2`, and  `tau`
+`max`, `min`, `pow`, `remainder`, `round`, `sign`, `sin`, `sqrt`, `tan`,
+`trunc`, `e`, `ln2`, `ln10`, `log10e`, `log2e`, `pi`, `sqrt1_2`, `sqrt2`, and
+`tau`
 
 Bugfixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Added various functions and constants from `purescript-math`. Specifically,
+`abs`, `acos`, `asin`, `atan`, `atan2`, `ceil`, `cos`, `exp`, `floor`, `log`,
+`max`, `min`, `pow`, `remainder`, `round`, `sin`, `sqrt`, `tan`, `trunc`, `e`,
+`ln2`, `ln10`, `log10e`, `log2e`, `pi`, `sqrt1_2`, `sqrt2`, and  `tau`
 
 Bugfixes:
 
 Other improvements:
+- Removed dependency on `purescript-math`
 
 ## [v8.0.0](https://github.com/purescript/purescript-numbers/releases/tag/v7.0.0) - 2021-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
-- Added various functions and constants from `purescript-math` (#18). Specifically,
-`abs`, `acos`, `asin`, `atan`, `atan2`, `ceil`, `cos`, `exp`, `floor`, `log`,
-`max`, `min`, `pow`, `remainder`, `round`, `sign`, `sin`, `sqrt`, `tan`,
-`trunc`, `e`, `ln2`, `ln10`, `log10e`, `log2e`, `pi`, `sqrt1_2`, `sqrt2`, and
-`tau`
+- Ported various functions & constants from `purescript-math` (#18 by @JamieBallingall)
+
+  Specifically...
+  - `abs`, `sign`
+  - `max`, `min` (which work differently than `Number`'s `Ord` instance)
+  - `ceil`, `floor`, `trunc`, `remainder`, `round`
+  - `log`, `ln2`, `ln10`, `log10e`, `log2e`
+  - `exp`, `pow`, `sqrt`, `sqrt1_2`, `sqrt2`
+  - `acos`, `asin`, `atan`, `atan2`, `cos`, `sin`, `tan`
+  - `e`, `pi`, `tau`
 
 Bugfixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Notable changes to this project are documented in this file. The format is based
 ## [Unreleased]
 
 Breaking changes:
+
+New features:
+
+Bugfixes:
+
+Other improvements:
+
+## [v7.0.0](https://github.com/purescript/purescript-numbers/releases/tag/v7.0.0) - 2021-02-26
+
+Breaking changes:
 - Added support for PureScript 0.14 and dropped support for all previous versions (#11)
 
 New features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,12 @@ New features:
   Specifically...
   - `abs`, `sign`
   - `max`, `min` (which work differently than `Number`'s `Ord` instance)
-  - `ceil`, `floor`, `trunc`, `remainder`, `round`
-  - `log`, `ln2`, `ln10`, `log10e`, `log2e`
-  - `exp`, `pow`, `sqrt`, `sqrt1_2`, `sqrt2`
+  - `ceil`, `floor`, `trunc`, `remainder`/`%`, `round`
+  - `log`
+  - `exp`, `pow`, `sqrt`
   - `acos`, `asin`, `atan`, `atan2`, `cos`, `sin`, `tan`
-  - `e`, `pi`, `tau`
+  - Numeric constants: `e`, `ln2`, `ln10`, `log10e`, `log2e`, `pi`, `sqrt1_2`,
+  `sqrt2`, and `tau`
 
 Bugfixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,13 @@ Bugfixes:
 
 Other improvements:
 
-## [v7.0.0](https://github.com/purescript/purescript-numbers/releases/tag/v7.0.0) - 2021-02-26
+## [v8.0.0](https://github.com/purescript/purescript-numbers/releases/tag/v7.0.0) - 2021-02-26
 
 Breaking changes:
 - Added support for PureScript 0.14 and dropped support for all previous versions (#11)
 
 New features:
 - Ported `Number`-related code from deprecated `purescript-globals` into this repo (#12)
-
-Bugfixes:
 
 Other improvements:
 - Replaced unicode symbols with ascii characters (#11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
-- Added various functions and constants from `purescript-math`. Specifically,
+- Added various functions and constants from `purescript-math` (#18). Specifically,
 `abs`, `acos`, `asin`, `atan`, `atan2`, `ceil`, `cos`, `exp`, `floor`, `log`,
 `max`, `min`, `pow`, `remainder`, `round`, `sign`, `sin`, `sqrt`, `tan`,
 `trunc`, `e`, `ln2`, `ln10`, `log10e`, `log2e`, `pi`, `sqrt1_2`, `sqrt2`, and

--- a/README.md
+++ b/README.md
@@ -12,168 +12,23 @@ Utility functions for working with PureScripts builtin `Number` type.
 spago install numbers
 ```
 
-## Examples
+## Scope
 
-Parsing:
-
-```purs
-> fromString "12.34"
-(Just 12.34)
-
-> fromString "1e-3"
-(Just 0.001)
-```
-
-Formatting (`Data.Number.Format`):
-
-```purs
-> let x = 1234.56789
-
-> toStringWith (precision 6) x
-"1234.57"
-
-> toStringWith (fixed 3) x
-"1234.568"
-
-> toStringWith (exponential 2) x
-"1.23e+3"
-```
-
-Approximate comparisons (`Data.Number.Approximate`):
-
-```purs
-> 0.1 + 0.2 == 0.3
-false
-
-> 0.1 + 0.2 ≅ 0.3
-true
-```
-
-_NaN_ and _infinity_:
-
-```purs
-> isNaN (Math.asin 2.0)
-true
-
-> isFinite (1.0 / 0.0)
-false
-```
-
-Remainder:
-```purs
-> 5.3 % 2.0
-1.2999999999999998
-```
-
-Trignometric functions:
-```purs
-> sin 0.0
-0.0
-
-> cos 0.0
-1.0
-
-> tan 0.0
-0.0
-```
-
-Inverse trignometric functions:
-```purs
-> asin 0.0
-0.0
-
-> acos 0.0 - pi / 2.0
-0.0
-
-> atan 0.0
-0.0
-
-> atan2 0.0 1.0
-0.0
-```
-
-Natural logarithm and exponent:
-```purs
-> log (exp 42.0)
-42.0
-```
-
-Square root and powers:
-```purs
-> sqrt (42.0 `pow` 2.0)
-42.0
-```
-
-Rounding functions:
-```purs
-> x = 1.5
-> ceil x
-2.0
-
-> floor x
-1.0
-
-> round x
-2.0
-
-> trunc x
-1.0
-```
-
-Numeric minimum and maximum:
-```purs
-> import Data.Number as Num
-> import Data.Ord as Ord
-> Num.min 0.0 1.0
-0.0
-
-> Num.max 0.0 1.0
-1.0
-
-> Num.min Num.nan 0.0
-NaN
-
-> Ord.min Num.nan 0.0
-0.0
-```
-
-Constants:
-```purs
-> e
-2.718281828459045
-
-> ln 2
-0.6931471805599453
-
-> ln10
-2.302585092994046
-
-> log10e
-0.4342944819032518
-
-> log2e
-1.4426950408889634
-
-> pi
-3.141592653589793
-
-> sqrt1_2
-0.7071067811865476
-
-> sqrt2
-1.4142135623730951
-
-> tau
-6.283185307179586
-```
-
-Sign and absolute value:
-```purs
-> x = -42.0
-> sign x * abs x == x
-true
-```
-
+* Parsing with `fromString`
+* Formating with `toStringWith`, see `Data.Number.Format`
+* Approximate comparisions with `≅`, see `Data.Number.Approximate`
+* Not-a-number and infinite value detection with `isNaN` and `isFinite`
+* Remainder with `%`
+* Trignometric functions with `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, and
+  `atan2`
+* Natural logarithm and exponents with `log` and `exp`
+* Powers with `sqrt` and `pow`
+* Rounding with `ceil`, `floor`, `round`, and `trunc`
+* Numeric minimum and maximum with `min` and `max`, which behave differently to
+  the versions in `Data.Ord` on values of `NaN`
+* Sign and absolute value functions `sign` and `abs`
+* Numeric constants `e`, `ln 2`, `ln10`, `log10e`, `log2e`, `pi`, `sqrt1_2`,
+  `sqrt2`, and `tau`
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,122 @@ true
 false
 ```
 
+Remainder:
+```purs
+> 5.3 % 2.0
+1.2999999999999998
+```
+
+Trignometric functions:
+```purs
+> sin 0.0
+0.0
+
+> cos 0.0
+1.0
+
+> tan 0.0
+0.0
+```
+
+Inverse trignometric functions:
+```purs
+> asin 0.0
+0.0
+
+> acos 0.0 - pi / 2.0
+0.0
+
+> atan 0.0
+0.0
+
+> atan2 0.0 1.0
+0.0
+```
+
+Natural logarithm and exponent:
+```purs
+> log (exp 42.0)
+42.0
+```
+
+Square root and powers:
+```purs
+> sqrt (42.0 `pow` 2.0)
+42.0
+```
+
+Rounding functions:
+```purs
+> x = 1.5
+> ceil x
+2.0
+
+> floor x
+1.0
+
+> round x
+2.0
+
+> trunc x
+1.0
+```
+
+Numeric minimum and maximum:
+```purs
+> import Data.Number as Num
+> import Data.Ord as Ord
+> Num.min 0.0 1.0
+0.0
+
+> Num.max 0.0 1.0
+1.0
+
+> Num.min Num.nan 0.0
+NaN
+
+> Ord.min Num.nan 0.0
+0.0
+```
+
+Constants:
+```purs
+> e
+2.718281828459045
+
+> ln 2
+0.6931471805599453
+
+> ln10
+2.302585092994046
+
+> log10e
+0.4342944819032518
+
+> log2e
+1.4426950408889634
+
+> pi
+3.141592653589793
+
+> sqrt1_2
+0.7071067811865476
+
+> sqrt2
+1.4142135623730951
+
+> tau
+6.283185307179586
+```
+
+Sign and absolute value:
+```purs
+> x = -42.0
+> sign x * abs x == x
+true
+```
+
+
 ## Documentation
 
 Module documentation is [published on Pursuit](http://pursuit.purescript.org/packages/purescript-numbers).

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,6 @@
   ],
   "dependencies": {
     "purescript-functions": "^5.0.0",
-    "purescript-math": "^3.0.0",
     "purescript-maybe": "^5.0.0"
   },
   "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/purescript/purescript-numbers.git"
+    "url": "https://github.com/purescript/purescript-numbers.git"
   },
   "ignore": [
     "**/.*",
@@ -16,12 +16,12 @@
     "output"
   ],
   "dependencies": {
-    "purescript-math": "master",
-    "purescript-maybe": "master",
-    "purescript-functions": "master"
+    "purescript-functions": "^5.0.0",
+    "purescript-math": "^3.0.0",
+    "purescript-maybe": "^5.0.0"
   },
   "devDependencies": {
-    "purescript-console": "master",
-    "purescript-assert": "master"
+    "purescript-assert": "^5.0.0",
+    "purescript-console": "^5.0.0"
   }
 }

--- a/src/Data/Number.js
+++ b/src/Data/Number.js
@@ -77,3 +77,7 @@ exports.sin = Math.sin;
 exports.sqrt = Math.sqrt;
 
 exports.tan = Math.tan;
+
+exports.trunc = Math.trunc ? Math.trunc : function(x) {
+  return x < 0 ? Math.ceil(x) : Math.floor(x);
+}

--- a/src/Data/Number.js
+++ b/src/Data/Number.js
@@ -68,11 +68,9 @@ exports.remainder = function (n) {
 
 exports.round = Math.round;
 
-signPolyfill = function(x) {
+exports.sign = Math.sign ? Math.sign : function(x) {
   return x === 0 || x !== x ? x : (x < 0 ? -1 : 1);
-}
-
-exports.sign = Math.sign ? Math.sign : exports.signPolyfill;
+};
 
 exports.sin = Math.sin;
 

--- a/src/Data/Number.js
+++ b/src/Data/Number.js
@@ -17,3 +17,59 @@ exports.fromStringImpl = function(str, isFinite, just, nothing) {
     return nothing;
   }
 };
+
+exports.abs = Math.abs;
+
+exports.acos = Math.acos;
+
+exports.asin = Math.asin;
+
+exports.atan = Math.atan;
+
+exports.atan2 = function (y) {
+  return function (x) {
+    return Math.atan2(y, x);
+  };
+};
+
+exports.ceil = Math.ceil;
+
+exports.cos = Math.cos;
+
+exports.exp = Math.exp;
+
+exports.floor = Math.floor;
+
+exports.log = Math.log;
+
+exports.max = function (n1) {
+  return function (n2) {
+    return Math.max(n1, n2);
+  };
+};
+
+exports.min = function (n1) {
+  return function (n2) {
+    return Math.min(n1, n2);
+  };
+};
+
+exports.pow = function (n) {
+  return function (p) {
+    return Math.pow(n, p);
+  };
+};
+
+exports.remainder = function (n) {
+  return function (m) {
+    return n % m;
+  };
+};
+
+exports.round = Math.round;
+
+exports.sin = Math.sin;
+
+exports.sqrt = Math.sqrt;
+
+exports.tan = Math.tan;

--- a/src/Data/Number.js
+++ b/src/Data/Number.js
@@ -68,6 +68,12 @@ exports.remainder = function (n) {
 
 exports.round = Math.round;
 
+signPolyfill = function(x) {
+  return x === 0 || x !== x ? x : (x < 0 ? -1 : 1);
+}
+
+exports.sign = Math.sign ? Math.sign : exports.signPolyfill;
+
 exports.sin = Math.sin;
 
 exports.sqrt = Math.sqrt;

--- a/src/Data/Number.purs
+++ b/src/Data/Number.purs
@@ -5,7 +5,6 @@ module Data.Number
   , isNaN
   , infinity
   , isFinite
-  , Radians
   , abs
   , acos
   , asin
@@ -85,33 +84,30 @@ fromString str = runFn4 fromStringImpl str isFinite Just Nothing
 
 foreign import fromStringImpl :: Fn4 String (Number -> Boolean) (forall a. a -> Maybe a) (forall a. Maybe a) (Maybe Number)
 
--- | An alias to make types in this module more explicit.
-type Radians = Number
-
 -- | Returns the absolute value of the argument.
 foreign import abs :: Number -> Number
 
--- | Returns the inverse cosine of the argument.
-foreign import acos :: Number -> Radians
+-- | Returns the inverse cosine in radians of the argument.
+foreign import acos :: Number -> Number
 
--- | Returns the inverse sine of the argument.
-foreign import asin :: Number -> Radians
+-- | Returns the inverse sine in radians of the argument.
+foreign import asin :: Number -> Number
 
--- | Returns the inverse tangent of the argument.
-foreign import atan :: Number -> Radians
+-- | Returns the inverse tangent in radians of the argument.
+foreign import atan :: Number -> Number
 
 -- | Four-quadrant tangent inverse. Given the arguments `y` and `x`, returns
 -- | the inverse tangent of `y / x`, where the signs of both arguments are used
 -- | to determine the sign of the result.
 -- | If the first argument is negative, the result will be negative.
 -- | The result is the angle between the positive x axis and  a point `(x, y)`.
-foreign import atan2 :: Number -> Number -> Radians
+foreign import atan2 :: Number -> Number -> Number
 
 -- | Returns the smallest integer not smaller than the argument.
 foreign import ceil :: Number -> Number
 
--- | Returns the cosine of the argument.
-foreign import cos :: Radians -> Number
+-- | Returns the cosine of the argument, where the argument is in radians.
+foreign import cos :: Number -> Number
 
 -- | Returns `e` exponentiated to the power of the argument.
 foreign import exp :: Number -> Number
@@ -146,14 +142,14 @@ foreign import round :: Number -> Number
 -- | NaN it will return NaN.
 foreign import sign :: Number -> Number
 
--- | Returns the sine of the argument.
-foreign import sin :: Radians -> Number
+-- | Returns the sine of the argument, where the argument is in radians.
+foreign import sin :: Number -> Number
 
 -- | Returns the square root of the argument.
 foreign import sqrt :: Number -> Number
 
--- | Returns the tangent of the argument.
-foreign import tan :: Radians -> Number
+-- | Returns the tangent of the argument, where the argument is in radians.
+foreign import tan :: Number -> Number
 
 -- | Truncates the decimal portion of a number. Equivalent to `floor` if the
 -- | number is positive, and `ceil` if the number is negative.

--- a/src/Data/Number.purs
+++ b/src/Data/Number.purs
@@ -53,3 +53,39 @@ fromString :: String -> Maybe Number
 fromString str = runFn4 fromStringImpl str isFinite Just Nothing
 
 foreign import fromStringImpl :: Fn4 String (Number -> Boolean) (forall a. a -> Maybe a) (forall a. Maybe a) (Maybe Number)
+
+-- | The base of natural logarithms, *e*, around 2.71828.
+e :: Number
+e = 2.718281828459045
+
+-- | The natural logarithm of 2, around 0.6931.
+ln2 :: Number
+ln2 = 0.6931471805599453
+
+-- | The natural logarithm of 10, around 2.3025.
+ln10 :: Number
+ln10 = 2.302585092994046
+
+-- | Base 10 logarithm of `e`, around 0.43429.
+log10e :: Number
+log10e = 0.4342944819032518
+
+-- | The base 2 logarithm of `e`, around 1.4426.
+log2e :: Number
+log2e = 1.4426950408889634
+
+-- | The ratio of the circumference of a circle to its diameter, around 3.14159.
+pi :: Number
+pi = 3.141592653589793
+
+-- | The Square root of one half, around 0.707107.
+sqrt1_2 :: Number
+sqrt1_2 = 0.7071067811865476
+
+-- | The square root of two, around 1.41421.
+sqrt2 :: Number
+sqrt2 = 1.4142135623730951
+
+-- | The ratio of the circumference of a circle to its radius, around 6.283185.
+tau :: Number
+tau = 6.283185307179586

--- a/src/Data/Number.purs
+++ b/src/Data/Number.purs
@@ -122,10 +122,12 @@ foreign import floor :: Number -> Number
 -- | Returns the natural logarithm of a number.
 foreign import log :: Number -> Number
 
--- | Returns the largest of two numbers.
+-- | Returns the largest of two numbers. Unlike `max` in Data.Ord this version
+-- | returns NaN if either argument is NaN.
 foreign import max :: Number -> Number -> Number
 
--- | Returns the smallest of two numbers.
+-- | Returns the smallest of two numbers. Unlike `min` in Data.Ord this version
+-- | returns NaN if either argument is NaN.
 foreign import min :: Number -> Number -> Number
 
 -- | Return  the first argument exponentiated to the power of the second argument.

--- a/src/Data/Number.purs
+++ b/src/Data/Number.purs
@@ -125,22 +125,22 @@ foreign import abs :: Number -> Number
 
 -- | Returns the inverse cosine in radians of the argument.
 -- | ```purs
--- | > acos 0.0 - pi / 2.0
--- | 0.0
+-- | > acos 0.0 == pi / 2.0
+-- | true
 -- | ```
 foreign import acos :: Number -> Number
 
 -- | Returns the inverse sine in radians of the argument.
 -- | ```purs
--- | > asin 0.0
--- | 0.0
+-- | > asin 1.0 == pi / 2.0
+-- | true
 -- | ```
 foreign import asin :: Number -> Number
 
 -- | Returns the inverse tangent in radians of the argument.
 -- | ```purs
--- | > atan 0.0
--- | 0.0
+-- | > atan 1.0 == pi / 4.0
+-- | true
 -- | ```
 foreign import atan :: Number -> Number
 
@@ -152,6 +152,8 @@ foreign import atan :: Number -> Number
 -- | ```purs
 -- | > atan2 0.0 1.0
 -- | 0.0
+-- | > atan2 1.0 0.0 == pi / 2.0
+-- | true
 -- | ```
 foreign import atan2 :: Number -> Number -> Number
 
@@ -164,8 +166,8 @@ foreign import ceil :: Number -> Number
 
 -- | Returns the cosine of the argument, where the argument is in radians.
 -- | ```purs
--- | > cos 0.0
--- | 1.0
+-- | > cos (pi / 4.0) == sqrt2 / 2.0
+-- | true
 -- | ```
 foreign import cos :: Number -> Number
 
@@ -235,8 +237,8 @@ foreign import sign :: Number -> Number
 
 -- | Returns the sine of the argument, where the argument is in radians.
 -- | ```purs
--- | > sin 0.0
--- | 0.0
+-- | > sin (pi / 2.0)
+-- | 1.0
 -- | ```
 foreign import sin :: Number -> Number
 
@@ -249,8 +251,8 @@ foreign import sqrt :: Number -> Number
 
 -- | Returns the tangent of the argument, where the argument is in radians.
 -- | ```
--- | > tan 0.0
--- | 0.0
+-- | > tan (pi / 4.0)
+-- | 0.9999999999999999
 -- | ```
 foreign import tan :: Number -> Number
 

--- a/src/Data/Number.purs
+++ b/src/Data/Number.purs
@@ -5,10 +5,40 @@ module Data.Number
   , isNaN
   , infinity
   , isFinite
+  , Radians
+  , abs
+  , acos
+  , asin
+  , atan
+  , atan2
+  , ceil
+  , cos
+  , exp
+  , floor
+  , log
+  , max
+  , min
+  , pow
+  , remainder, (%)
+  , round
+  , sin
+  , sqrt
+  , tan
+  , trunc
+  , e
+  , ln2
+  , ln10
+  , log10e
+  , log2e
+  , pi
+  , sqrt1_2
+  , sqrt2
+  , tau
   ) where
 
 import Data.Function.Uncurried (Fn4, runFn4)
 import Data.Maybe (Maybe(..))
+import Data.Ord ((<))
 
 -- | Not a number (NaN)
 foreign import nan :: Number
@@ -53,6 +83,74 @@ fromString :: String -> Maybe Number
 fromString str = runFn4 fromStringImpl str isFinite Just Nothing
 
 foreign import fromStringImpl :: Fn4 String (Number -> Boolean) (forall a. a -> Maybe a) (forall a. Maybe a) (Maybe Number)
+
+-- | An alias to make types in this module more explicit.
+type Radians = Number
+
+-- | Returns the absolute value of the argument.
+foreign import abs :: Number -> Number
+
+-- | Returns the inverse cosine of the argument.
+foreign import acos :: Number -> Radians
+
+-- | Returns the inverse sine of the argument.
+foreign import asin :: Number -> Radians
+
+-- | Returns the inverse tangent of the argument.
+foreign import atan :: Number -> Radians
+
+-- | Four-quadrant tangent inverse. Given the arguments `y` and `x`, returns
+-- | the inverse tangent of `y / x`, where the signs of both arguments are used
+-- | to determine the sign of the result.
+-- | If the first argument is negative, the result will be negative.
+-- | The result is the angle between the positive x axis and  a point `(x, y)`.
+foreign import atan2 :: Number -> Number -> Radians
+
+-- | Returns the smallest integer not smaller than the argument.
+foreign import ceil :: Number -> Number
+
+-- | Returns the cosine of the argument.
+foreign import cos :: Radians -> Number
+
+-- | Returns `e` exponentiated to the power of the argument.
+foreign import exp :: Number -> Number
+
+-- | Returns the largest integer not larger than the argument.
+foreign import floor :: Number -> Number
+
+-- | Returns the natural logarithm of a number.
+foreign import log :: Number -> Number
+
+-- | Returns the largest of two numbers.
+foreign import max :: Number -> Number -> Number
+
+-- | Returns the smallest of two numbers.
+foreign import min :: Number -> Number -> Number
+
+-- | Return  the first argument exponentiated to the power of the second argument.
+foreign import pow :: Number -> Number -> Number
+
+-- | Computes the remainder after division, wrapping Javascript's `%` operator.
+foreign import remainder :: Number -> Number -> Number
+
+infixl 7 remainder as %
+
+-- | Returns the integer closest to the argument.
+foreign import round :: Number -> Number
+
+-- | Returns the sine of the argument.
+foreign import sin :: Radians -> Number
+
+-- | Returns the square root of the argument.
+foreign import sqrt :: Number -> Number
+
+-- | Returns the tangent of the argument.
+foreign import tan :: Radians -> Number
+
+-- | Truncates the decimal portion of a number. Equivalent to `floor` if the
+-- | number is positive, and `ceil` if the number is negative.
+trunc :: Number -> Number
+trunc x = if x < 0.0 then ceil x else floor x
 
 -- | The base of natural logarithms, *e*, around 2.71828.
 e :: Number

--- a/src/Data/Number.purs
+++ b/src/Data/Number.purs
@@ -38,7 +38,6 @@ module Data.Number
 
 import Data.Function.Uncurried (Fn4, runFn4)
 import Data.Maybe (Maybe(..))
-import Data.Ord ((<))
 
 -- | Not a number (NaN).
 -- | ```purs
@@ -262,8 +261,7 @@ foreign import tan :: Number -> Number
 -- | ceil 1.5
 -- | 2.0
 -- | ```
-trunc :: Number -> Number
-trunc x = if x < 0.0 then ceil x else floor x
+foreign import trunc :: Number -> Number
 
 -- | The base of the natural logarithm, also known as Euler's number or *e*.
 -- | ```purs

--- a/src/Data/Number.purs
+++ b/src/Data/Number.purs
@@ -21,6 +21,7 @@ module Data.Number
   , pow
   , remainder, (%)
   , round
+  , sign
   , sin
   , sqrt
   , tan
@@ -137,6 +138,11 @@ infixl 7 remainder as %
 
 -- | Returns the integer closest to the argument.
 foreign import round :: Number -> Number
+
+-- | Returns either a positive or negative +/- 1, indicating the sign of the
+-- | argument. If the argument is 0, it will return a +/- 0. If the argument is
+-- | NaN it will return NaN.
+foreign import sign :: Number -> Number
 
 -- | Returns the sine of the argument.
 foreign import sin :: Radians -> Number

--- a/src/Data/Number.purs
+++ b/src/Data/Number.purs
@@ -172,8 +172,8 @@ foreign import cos :: Number -> Number
 
 -- | Returns `e` exponentiated to the power of the argument.
 -- | ```purs
--- | > exp 0.0
--- | 1.0
+-- | > exp 1.0
+-- | 2.718281828459045
 -- | ```
 foreign import exp :: Number -> Number
 
@@ -186,8 +186,8 @@ foreign import floor :: Number -> Number
 
 -- | Returns the natural logarithm of a number.
 -- | ```purs
--- | > log 1.0
--- | 0.0
+-- | > log e
+-- | 1.0
 foreign import log :: Number -> Number
 
 -- | Returns the largest of two numbers. Unlike `max` in Data.Ord this version

--- a/src/Data/Number.purs
+++ b/src/Data/Number.purs
@@ -40,16 +40,47 @@ import Data.Function.Uncurried (Fn4, runFn4)
 import Data.Maybe (Maybe(..))
 import Data.Ord ((<))
 
--- | Not a number (NaN)
+-- | Not a number (NaN).
+-- | ```purs
+-- | > nan
+-- | NaN
+-- | ```
 foreign import nan :: Number
 
--- | Test whether a number is NaN
+-- | Test whether a number is NaN.
+-- | ```purs
+-- | > isNaN 0.0
+-- | false
+-- |
+-- | > isNaN nan
+-- | true
+-- | ```
 foreign import isNaN :: Number -> Boolean
 
--- | Positive infinity
+-- | Positive infinity. For negative infinity use `(-infinity)`
+-- | ```purs
+-- | > infinity
+-- | Infinity
+-- |
+-- | > (-infinity)
+-- | - Infinity
+-- | ```
 foreign import infinity :: Number
 
--- | Test whether a number is finite
+-- | Test whether a number is finite.
+-- | ```purs
+-- | > isFinite 0.0
+-- | true
+-- |
+-- | > isFinite infinity
+-- | false
+-- |
+-- | > isFinite (-infinity)
+-- | false
+-- |
+-- | > isFinite nan
+-- | false
+-- | ```
 foreign import isFinite :: Number -> Boolean
 
 -- | Attempt to parse a `Number` using JavaScripts `parseFloat`. Returns
@@ -85,37 +116,77 @@ fromString str = runFn4 fromStringImpl str isFinite Just Nothing
 foreign import fromStringImpl :: Fn4 String (Number -> Boolean) (forall a. a -> Maybe a) (forall a. Maybe a) (Maybe Number)
 
 -- | Returns the absolute value of the argument.
+-- | ```purs
+-- | > x = -42.0
+-- | > sign x * abs x == x
+-- | true
+-- | ```
 foreign import abs :: Number -> Number
 
 -- | Returns the inverse cosine in radians of the argument.
+-- | ```purs
+-- | > acos 0.0 - pi / 2.0
+-- | 0.0
+-- | ```
 foreign import acos :: Number -> Number
 
 -- | Returns the inverse sine in radians of the argument.
+-- | ```purs
+-- | > asin 0.0
+-- | 0.0
+-- | ```
 foreign import asin :: Number -> Number
 
 -- | Returns the inverse tangent in radians of the argument.
+-- | ```purs
+-- | > atan 0.0
+-- | 0.0
+-- | ```
 foreign import atan :: Number -> Number
 
 -- | Four-quadrant tangent inverse. Given the arguments `y` and `x`, returns
 -- | the inverse tangent of `y / x`, where the signs of both arguments are used
 -- | to determine the sign of the result.
 -- | If the first argument is negative, the result will be negative.
--- | The result is the angle between the positive x axis and  a point `(x, y)`.
+-- | The result is the angle between the positive x axis and a point `(x, y)`.
+-- | ```purs
+-- | > atan2 0.0 1.0
+-- | 0.0
+-- | ```
 foreign import atan2 :: Number -> Number -> Number
 
 -- | Returns the smallest integer not smaller than the argument.
+-- | ```purs
+-- | > ceil 1.5
+-- | 2.0
+-- | ```
 foreign import ceil :: Number -> Number
 
 -- | Returns the cosine of the argument, where the argument is in radians.
+-- | ```purs
+-- | > cos 0.0
+-- | 1.0
+-- | ```
 foreign import cos :: Number -> Number
 
 -- | Returns `e` exponentiated to the power of the argument.
+-- | ```purs
+-- | > exp 0.0
+-- | 1.0
+-- | ```
 foreign import exp :: Number -> Number
 
 -- | Returns the largest integer not larger than the argument.
+-- | ```purs
+-- | > floor 1.5
+-- | 1.0
+-- | ```
 foreign import floor :: Number -> Number
 
 -- | Returns the natural logarithm of a number.
+-- | ```purs
+-- | > log 1.0
+-- | 0.0
 foreign import log :: Number -> Number
 
 -- | Returns the largest of two numbers. Unlike `max` in Data.Ord this version
@@ -127,67 +198,166 @@ foreign import max :: Number -> Number -> Number
 foreign import min :: Number -> Number -> Number
 
 -- | Return  the first argument exponentiated to the power of the second argument.
+-- | ```purs
+-- | > pow 3.0 2.0
+-- | 9.0
+-- | > sqrt 42.0 == pow 42.0 0.5
+-- | true
+-- | ```
+
 foreign import pow :: Number -> Number -> Number
 
 -- | Computes the remainder after division. This is the same as JavaScript's `%` operator.
+-- ```purs
+-- > 5.3 % 2.0
+-- 1.2999999999999998
+-- ```
 foreign import remainder :: Number -> Number -> Number
 
 infixl 7 remainder as %
 
 -- | Returns the integer closest to the argument.
+-- | ```purs
+-- | > round 1.5
+-- | 2.0
+-- | ```
 foreign import round :: Number -> Number
 
 -- | Returns either a positive or negative +/- 1, indicating the sign of the
 -- | argument. If the argument is 0, it will return a +/- 0. If the argument is
 -- | NaN it will return NaN.
+-- | ```purs
+-- | > x = -42.0
+-- | > sign x * abs x == x
+-- | true
+-- | ```
 foreign import sign :: Number -> Number
 
 -- | Returns the sine of the argument, where the argument is in radians.
+-- | ```purs
+-- | > sin 0.0
+-- | 0.0
+-- | ```
 foreign import sin :: Number -> Number
 
 -- | Returns the square root of the argument.
+-- | ```purs
+-- | > sqrt 49.0
+-- | 7.0
+-- | ```
 foreign import sqrt :: Number -> Number
 
 -- | Returns the tangent of the argument, where the argument is in radians.
+-- | ```
+-- | > tan 0.0
+-- | 0.0
+-- | ```
 foreign import tan :: Number -> Number
 
 -- | Truncates the decimal portion of a number. Equivalent to `floor` if the
 -- | number is positive, and `ceil` if the number is negative.
+-- | ```purs
+-- | ceil 1.5
+-- | 2.0
+-- | ```
 trunc :: Number -> Number
 trunc x = if x < 0.0 then ceil x else floor x
 
--- | The base of natural logarithms, *e*, around 2.71828.
+-- | The base of the natural logarithm, also known as Euler's number or *e*.
+-- | ```purs
+-- | > log e
+-- | 1.0
+-- |
+-- | > exp 1.0 == e
+-- | true
+-- |
+-- | > e
+-- | 2.718281828459045
+-- | ```
 e :: Number
 e = 2.718281828459045
 
--- | The natural logarithm of 2, around 0.6931.
+-- | The natural logarithm of 2.
+-- | ```purs
+-- | > log 2.0 == ln2
+-- | true
+-- |
+-- | > ln2
+-- | 0.6931471805599453
+-- | ```
 ln2 :: Number
 ln2 = 0.6931471805599453
 
--- | The natural logarithm of 10, around 2.3025.
+-- | The natural logarithm of 10.
+-- | ```purs
+-- | > log 10.0 == ln10
+-- | true
+-- |
+-- | > ln10
+-- | 2.302585092994046
+-- | ```
 ln10 :: Number
 ln10 = 2.302585092994046
 
--- | Base 10 logarithm of `e`, around 0.43429.
+-- | Base 10 logarithm of `e`.
+-- | ```purs
+-- | > 1.0 / ln10 - log10e
+-- | -5.551115123125783e-17
+-- |
+-- | > log10e
+-- | 0.4342944819032518
+-- | ```
 log10e :: Number
 log10e = 0.4342944819032518
 
--- | The base 2 logarithm of `e`, around 1.4426.
+-- | The base 2 logarithm of `e`.
+-- | ```purs
+-- | > 1.0 / ln2 == log2e
+-- | true
+-- |
+-- | > log2e
+-- | 1.4426950408889634
+-- | ```
 log2e :: Number
 log2e = 1.4426950408889634
 
--- | The ratio of the circumference of a circle to its diameter, around 3.14159.
+-- | The ratio of the circumference of a circle to its diameter.
+-- | ```purs
+-- | > pi
+-- | 3.141592653589793
+-- | ```
 pi :: Number
 pi = 3.141592653589793
 
--- | The square root of one half, around 0.707107.
+-- | The square root of one half.
+-- | ```purs
+-- | > sqrt 0.5 == sqrt1_2
+-- | true
+-- |
+-- | > sqrt1_2
+-- | 0.7071067811865476
+-- | ```
 sqrt1_2 :: Number
 sqrt1_2 = 0.7071067811865476
 
--- | The square root of two, around 1.41421.
+-- | The square root of two.
+-- | ```purs
+-- | > sqrt 2.0 == sqrt2
+-- | true
+-- |
+-- | > sqrt2
+-- | 1.4142135623730951
+-- | ```
 sqrt2 :: Number
 sqrt2 = 1.4142135623730951
 
--- | The ratio of the circumference of a circle to its radius, around 6.283185.
+-- | The ratio of the circumference of a circle to its radius.
+-- | ```purs
+-- | > 2.0 * pi == tau
+-- | true
+-- |
+-- | > tau
+-- | 6.283185307179586
+-- | ```
 tau :: Number
 tau = 6.283185307179586

--- a/src/Data/Number/Approximate.purs
+++ b/src/Data/Number/Approximate.purs
@@ -13,7 +13,7 @@ module Data.Number.Approximate
 
 import Prelude
 
-import Math (abs)
+import Data.Number (abs)
 
 -- | A newtype for (small) numbers, typically in the range *[0:1]*. It is used
 -- | as an argument for `eqRelative`.
@@ -93,4 +93,3 @@ newtype Tolerance = Tolerance Number
 -- | ```
 eqAbsolute :: Tolerance -> Number -> Number -> Boolean
 eqAbsolute (Tolerance tolerance) x y = abs (x - y) <= tolerance
-

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -3,19 +3,21 @@ module Test.Main where
 import Prelude
 
 import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Number ((%), abs, acos, asin, atan, atan2, ceil, cos, exp, floor,
+fromString, infinity, isFinite, isNaN, ln10, ln2, log10e, log2e, nan, pi, pow,
+round, sign, sin, sqrt, sqrt1_2, sqrt2, tan, tau, trunc)
+import Data.Number (log) as Num
+import Data.Number.Approximate (Fraction(..), Tolerance(..), eqRelative, eqAbsolute, (≅), (≇))
+import Data.Number.Format (precision, fixed, exponential, toStringWith, toString)
 import Effect (Effect)
 import Effect.Console (log)
-
-import Data.Number (isFinite, infinity,nan, isNaN, fromString)
-import Data.Number.Format (precision, fixed, exponential, toStringWith, toString)
-import Data.Number.Approximate (Fraction(..), Tolerance(..), eqRelative, eqAbsolute, (≅), (≇))
-
 import Test.Assert (assert, assertTrue', assertFalse', assertEqual)
 
 main :: Effect Unit
 main = do
   globalsTestCode
   numbersTestCode
+  numericsTestCode
 
 -- Test code for the `purescript-globals` repo before its' Number-related
 -- code was moved into this repo
@@ -288,3 +290,205 @@ numbersTestCode = do
   log "\teqAbsolute (compare against 0)"
   assertTrue' "should succeed for numbers smaller than the tolerance" $
     0.0 ~= -0.09
+
+numericsTestCode :: Effect Unit
+numericsTestCode = do
+  let pi_4 = pi / 4.0
+  let pi_2 = pi / 2.0
+  let neg_pi = -pi
+
+  log "Data.Number.sin"
+  log "  sin 0.0 = 0.0"
+  sin 0.0 `assertNearlyEqual` 0.0
+
+  log "  sin (pi / 4.0) = sqrt1_2"
+  sin pi_4 `assertNearlyEqual` sqrt1_2
+
+  log "  sin (pi / 2.0) = 1.0"
+  sin pi_2 `assertNearlyEqual` 1.0
+
+  log "  sin pi = 0.0"
+  sin pi `assertNearlyEqual` 0.0
+
+  log "  sin tau = 0.0"
+  sin tau `assertNearlyEqual` 0.0
+
+  log "Data.Number.cos"
+  log "  cos 0.0 = 1.0"
+  cos 0.0 `assertNearlyEqual` 1.0
+
+  log "  cos (pi / 4.0) = sqrt1_2"
+  cos pi_4 `assertNearlyEqual` sqrt1_2
+
+  log "  cos (pi / 2.0) = 0.0"
+  cos pi_2 `assertNearlyEqual` 0.0
+
+  log "  cos pi = -1.0"
+  cos pi `assertNearlyEqual` -1.0
+
+  log "  cos tau = 1.0"
+  cos tau `assertNearlyEqual` 1.0
+
+  log "Data.Number.tan"
+  log "  tan 0.0 = 0.0"
+  tan 0.0 `assertNearlyEqual` 0.0
+
+  log "  tan (pi / 4.0) = 1.0"
+  tan pi_4 `assertNearlyEqual` 1.0
+
+  log "  tan pi = 0.0"
+  tan pi `assertNearlyEqual` 0.0
+
+  log "  tan tau = 0.0"
+  tan tau `assertNearlyEqual` 0.0
+
+  log "Data.Number.asin"
+  log "  asin (sin 0.0) = 0.0"
+  asin (sin 0.0) `assertNearlyEqual` 0.0
+
+  log "  asin (sin pi / 4.0) = pi / 4.0"
+  asin (sin pi_4) `assertNearlyEqual` pi_4
+
+  log "  asin (sin pi / 2.0) = pi / 2.0"
+  asin (sin pi_2) `assertNearlyEqual` pi_2
+
+  log "Data.Number.acos"
+  log "  acos (cos 0.0) = 0.0"
+  acos (cos 0.0) `assertNearlyEqual` 0.0
+
+  log "  acos (cos pi / 4.0) = pi / 4.0"
+  acos (cos pi_4) `assertNearlyEqual` pi_4
+
+  log "  acos (cos pi / 2.0) = pi / 2.0"
+  acos (cos pi_2) `assertNearlyEqual` pi_2
+
+  log "Data.Number.atan"
+  log "  atan (tan 0.0) = 0.0"
+  atan (tan 0.0) `assertNearlyEqual` 0.0
+
+  log "  atan (tan pi / 4.0) = pi / 4.0"
+  atan (tan pi_4) `assertNearlyEqual` pi_4
+
+  log "  atan (tan pi / 2.0) = pi / 2.0"
+  atan (tan pi_2) `assertNearlyEqual` pi_2
+
+  log "Data.Number.atan2"
+  log "  atan2 1.0 2.0 = atan (1.0 / 2.0)"
+  atan2 1.0 2.0 `assertNearlyEqual` atan (1.0 / 2.0)
+
+  log "Data.Number.log"
+  log "  log 2.0 = ln2"
+  Num.log 2.0 `assertNearlyEqual` ln2
+
+  log "  log 10.0 = ln10"
+  Num.log 10.0 `assertNearlyEqual` ln10
+
+  log "Data.Number.exp"
+  log "  exp ln2 = 2.0"
+  exp ln2 `assertNearlyEqual` 2.0
+
+  log "  exp ln10 = 10.0"
+  exp ln10 `assertNearlyEqual` 10.0
+
+  log "Data.Number.abs"
+  log "  abs pi = pi"
+  assert $ abs pi == pi
+
+  log "  abs (-pi) = pi"
+  assert $ abs neg_pi == pi
+
+  log "Data.Number.sign"
+  log "  sign pi = 1.0"
+  assert $ sign pi == 1.0
+
+  log "  sign (-pi) = -1.0"
+  assert $ sign neg_pi == -1.0
+
+  log "Data.Number.sqrt"
+  log "  sqrt 2.0 = sqrt2"
+  sqrt 2.0 `assertNearlyEqual` sqrt2
+
+  log "  sqrt (1.0 / 2.0) = sqrt1_2"
+  sqrt (1.0 / 2.0) `assertNearlyEqual` sqrt1_2
+
+  log "Data.Number.pow"
+  log "  2.0 `pow` (1.0 / 2.0) = sqrt2"
+  (2.0 `pow` (1.0 / 2.0)) `assertNearlyEqual` sqrt2
+
+  log "Data.Number.min"
+  log "  min 0.0 1.0 = 0.0"
+  assert $ min 0.0 1.0 == 0.0
+
+  log "Data.Number.max"
+  log "  max 0.0 1.0 = 1.0"
+  assert $ max 0.0 1.0 == 1.0
+
+  log "Data.Number rounding"
+  log "  ceil 4.7 = 5.0"
+  assert $ ceil 4.7 == 5.0
+
+  log "  floor 4.7 = 4.0"
+  assert $ floor 4.7 == 4.0
+
+  log "  round 4.7 = 5.0"
+  assert $ round 4.7 == 5.0
+
+  log "  trunc 4.7 = 4.0"
+  assert $ trunc 4.7 == 4.0
+
+  log "  ceil (-4.7) = -4.0"
+  assert $ ceil (-4.7) == -4.0
+
+  log "  floor (-4.7) = -5.0"
+  assert $ floor (-4.7) == -5.0
+
+  log "  round (-4.7) = -5.0"
+  assert $ round (-4.7) == -5.0
+
+  log "  trunc (-4.7) = -4.0"
+  assert $ trunc (-4.7) == -4.0
+
+  log "  ceil 4.3 = 5.0"
+  assert $ ceil 4.3 == 5.0
+
+  log "  floor 4.3 = 4.0"
+  assert $ floor 4.3 == 4.0
+
+  log "  round 4.3 = 4.0"
+  assert $ round 4.3 == 4.0
+
+  log "  trunc 4.3 = 4.0"
+  assert $ trunc 4.3 == 4.0
+
+  log "  ceil (-4.3) = -4.0"
+  assert $ ceil (-4.3) == -4.0
+
+  log "  floor (-4.3) = -5.0"
+  assert $ floor (-4.3) == -5.0
+
+  log "  round (-4.3) = -4.0"
+  assert $ round (-4.3) == -4.0
+
+  log "  trunc (-4.3) = -4.0"
+  assert $ trunc (-4.3) == -4.0
+
+  log "Data.Number.remainder (%)"
+  log "  12.0 % 5.0 = 2.0"
+  assert $ 12.0 % 5.0 == 2.0
+
+  log "  (-12.0) % 5.0 = 2.0"
+  assert $ (-12.0) % 5.0 == -2.0
+
+  log "Data.Number constants"
+  log "  log10e = 1.0 / ln10"
+  log10e `assertNearlyEqual` (1.0 / ln10)
+
+  log "  log2e = 1.0 / ln2"
+  log2e `assertNearlyEqual` (1.0 / ln2)
+
+assertNearlyEqual :: Number -> Number -> Effect Unit
+assertNearlyEqual x y = assert ((abs (x - y)) < 1e-12)
+
+
+
+-- `remainder`

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -23,8 +23,6 @@ main = do
 -- code was moved into this repo
 globalsTestCode :: Effect Unit
 globalsTestCode = do
-  let num = 12345.6789
-
   log "nan /= nan"
   assert $ nan /= nan
 
@@ -488,7 +486,3 @@ numericsTestCode = do
 
 assertNearlyEqual :: Number -> Number -> Effect Unit
 assertNearlyEqual x y = assert ((abs (x - y)) < 1e-12)
-
-
-
--- `remainder`

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -3,11 +3,9 @@ module Test.Main where
 import Prelude
 
 import Data.Maybe (Maybe(..), fromMaybe)
-import Data.Number ((%), abs, acos, asin, atan, atan2, ceil, cos, exp, floor,
-fromString, infinity, isFinite, isNaN, ln10, ln2, log10e, log2e, nan, pi, pow,
-round, sign, sin, sqrt, sqrt1_2, sqrt2, tan, tau, trunc)
+import Data.Number ((%), abs, acos, asin, atan, atan2, ceil, cos, exp, floor, fromString, infinity, isFinite, isNaN, ln10, ln2, log10e, log2e, nan, pi, pow, round, sign, sin, sqrt, sqrt1_2, sqrt2, tan, tau, trunc)
 import Data.Number (log) as Num
-import Data.Number.Approximate (Fraction(..), Tolerance(..), eqRelative, eqAbsolute, (≅), (≇))
+import Data.Number.Approximate (Fraction(..), Tolerance(..), eqAbsolute, eqRelative, (≅), (≇))
 import Data.Number.Format (precision, fixed, exponential, toStringWith, toString)
 import Effect (Effect)
 import Effect.Console (log)
@@ -291,102 +289,103 @@ numbersTestCode = do
 
 numericsTestCode :: Effect Unit
 numericsTestCode = do
+  let assertApproxEqual = \x y -> assert (eqAbsolute (Tolerance 1e-12) x y)
   let pi_4 = pi / 4.0
   let pi_2 = pi / 2.0
   let neg_pi = -pi
 
   log "Data.Number.sin"
   log "  sin 0.0 = 0.0"
-  sin 0.0 `assertNearlyEqual` 0.0
+  sin 0.0 `assertApproxEqual` 0.0
 
   log "  sin (pi / 4.0) = sqrt1_2"
-  sin pi_4 `assertNearlyEqual` sqrt1_2
+  sin pi_4 `assertApproxEqual` sqrt1_2
 
   log "  sin (pi / 2.0) = 1.0"
-  sin pi_2 `assertNearlyEqual` 1.0
+  sin pi_2 `assertApproxEqual` 1.0
 
   log "  sin pi = 0.0"
-  sin pi `assertNearlyEqual` 0.0
+  sin pi `assertApproxEqual` 0.0
 
   log "  sin tau = 0.0"
-  sin tau `assertNearlyEqual` 0.0
+  sin tau `assertApproxEqual` 0.0
 
   log "Data.Number.cos"
   log "  cos 0.0 = 1.0"
-  cos 0.0 `assertNearlyEqual` 1.0
+  cos 0.0 `assertApproxEqual` 1.0
 
   log "  cos (pi / 4.0) = sqrt1_2"
-  cos pi_4 `assertNearlyEqual` sqrt1_2
+  cos pi_4 `assertApproxEqual` sqrt1_2
 
   log "  cos (pi / 2.0) = 0.0"
-  cos pi_2 `assertNearlyEqual` 0.0
+  cos pi_2 `assertApproxEqual` 0.0
 
   log "  cos pi = -1.0"
-  cos pi `assertNearlyEqual` -1.0
+  cos pi `assertApproxEqual` -1.0
 
   log "  cos tau = 1.0"
-  cos tau `assertNearlyEqual` 1.0
+  cos tau `assertApproxEqual` 1.0
 
   log "Data.Number.tan"
   log "  tan 0.0 = 0.0"
-  tan 0.0 `assertNearlyEqual` 0.0
+  tan 0.0 `assertApproxEqual` 0.0
 
   log "  tan (pi / 4.0) = 1.0"
-  tan pi_4 `assertNearlyEqual` 1.0
+  tan pi_4 `assertApproxEqual` 1.0
 
   log "  tan pi = 0.0"
-  tan pi `assertNearlyEqual` 0.0
+  tan pi `assertApproxEqual` 0.0
 
   log "  tan tau = 0.0"
-  tan tau `assertNearlyEqual` 0.0
+  tan tau `assertApproxEqual` 0.0
 
   log "Data.Number.asin"
   log "  asin (sin 0.0) = 0.0"
-  asin (sin 0.0) `assertNearlyEqual` 0.0
+  asin (sin 0.0) `assertApproxEqual` 0.0
 
   log "  asin (sin pi / 4.0) = pi / 4.0"
-  asin (sin pi_4) `assertNearlyEqual` pi_4
+  asin (sin pi_4) `assertApproxEqual` pi_4
 
   log "  asin (sin pi / 2.0) = pi / 2.0"
-  asin (sin pi_2) `assertNearlyEqual` pi_2
+  asin (sin pi_2) `assertApproxEqual` pi_2
 
   log "Data.Number.acos"
   log "  acos (cos 0.0) = 0.0"
-  acos (cos 0.0) `assertNearlyEqual` 0.0
+  acos (cos 0.0) `assertApproxEqual` 0.0
 
   log "  acos (cos pi / 4.0) = pi / 4.0"
-  acos (cos pi_4) `assertNearlyEqual` pi_4
+  acos (cos pi_4) `assertApproxEqual` pi_4
 
   log "  acos (cos pi / 2.0) = pi / 2.0"
-  acos (cos pi_2) `assertNearlyEqual` pi_2
+  acos (cos pi_2) `assertApproxEqual` pi_2
 
   log "Data.Number.atan"
   log "  atan (tan 0.0) = 0.0"
-  atan (tan 0.0) `assertNearlyEqual` 0.0
+  atan (tan 0.0) `assertApproxEqual` 0.0
 
   log "  atan (tan pi / 4.0) = pi / 4.0"
-  atan (tan pi_4) `assertNearlyEqual` pi_4
+  atan (tan pi_4) `assertApproxEqual` pi_4
 
   log "  atan (tan pi / 2.0) = pi / 2.0"
-  atan (tan pi_2) `assertNearlyEqual` pi_2
+  atan (tan pi_2) `assertApproxEqual` pi_2
 
   log "Data.Number.atan2"
   log "  atan2 1.0 2.0 = atan (1.0 / 2.0)"
-  atan2 1.0 2.0 `assertNearlyEqual` atan (1.0 / 2.0)
+  atan2 1.0 2.0 `assertApproxEqual` atan (1.0 / 2.0)
 
   log "Data.Number.log"
   log "  log 2.0 = ln2"
-  Num.log 2.0 `assertNearlyEqual` ln2
+  Num.log 2.0 `assertApproxEqual` ln2
 
   log "  log 10.0 = ln10"
-  Num.log 10.0 `assertNearlyEqual` ln10
+  Num.log 10.0 `assertApproxEqual` ln10
 
   log "Data.Number.exp"
   log "  exp ln2 = 2.0"
-  exp ln2 `assertNearlyEqual` 2.0
+  exp ln2 `assertApproxEqual` 2.0
 
   log "  exp ln10 = 10.0"
-  exp ln10 `assertNearlyEqual` 10.0
+  exp ln10 `assertApproxEqual` 10.0
 
   log "Data.Number.abs"
   log "  abs pi = pi"
@@ -404,14 +403,14 @@ numericsTestCode = do
 
   log "Data.Number.sqrt"
   log "  sqrt 2.0 = sqrt2"
-  sqrt 2.0 `assertNearlyEqual` sqrt2
+  sqrt 2.0 `assertApproxEqual` sqrt2
 
   log "  sqrt (1.0 / 2.0) = sqrt1_2"
-  sqrt (1.0 / 2.0) `assertNearlyEqual` sqrt1_2
+  sqrt (1.0 / 2.0) `assertApproxEqual` sqrt1_2
 
   log "Data.Number.pow"
   log "  2.0 `pow` (1.0 / 2.0) = sqrt2"
-  (2.0 `pow` (1.0 / 2.0)) `assertNearlyEqual` sqrt2
+  (2.0 `pow` (1.0 / 2.0)) `assertApproxEqual` sqrt2
 
   log "Data.Number.min"
   log "  min 0.0 1.0 = 0.0"
@@ -479,10 +478,7 @@ numericsTestCode = do
 
   log "Data.Number constants"
   log "  log10e = 1.0 / ln10"
-  log10e `assertNearlyEqual` (1.0 / ln10)
+  log10e `assertApproxEqual` (1.0 / ln10)
 
   log "  log2e = 1.0 / ln2"
-  log2e `assertNearlyEqual` (1.0 / ln2)
-
-assertNearlyEqual :: Number -> Number -> Effect Unit
-assertNearlyEqual x y = assert ((abs (x - y)) < 1e-12)
+  log2e `assertApproxEqual` (1.0 / ln2)


### PR DESCRIPTION
Introduces many of the functions currently living in [purescript-math](https://github.com/purescript/purescript-math). Closes #17. See also purescript/purescript-math#31.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [X] Linked any existing issues or proposals that this pull request should close
- [X] Updated or added relevant documentation
- [X] Added a test for the contribution (if applicable)
