### PR TITLE
Missing `Number` properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Added `epsilon`, `negativeInfinity`, `maxValue`, and `minValue` from JavaScript’s `Number` properties (#19 by @toastal)
 
 Bugfixes:
 

--- a/src/Data/Number.js
+++ b/src/Data/Number.js
@@ -1,11 +1,15 @@
 /* globals exports */
 "use strict";
 
+exports.epsilon = Number.EPSILON;
+
 exports.nan = NaN;
 
 exports.isNaN = isNaN;
 
 exports.infinity = Infinity;
+
+exports.negativeInfinity = Number.NEGATIVE_INFINITY;
 
 exports.isFinite = isFinite;
 
@@ -17,3 +21,7 @@ exports.fromStringImpl = function(str, isFinite, just, nothing) {
     return nothing;
   }
 };
+
+exports.maxValue = Number.MAX_VALUE;
+
+exports.minValue = Number.MIN_VALUE;

--- a/src/Data/Number.purs
+++ b/src/Data/Number.purs
@@ -1,14 +1,24 @@
 -- | Functions for working with PureScripts builtin `Number` type.
 module Data.Number
   ( fromString
+  , epsilon
   , nan
   , isNaN
   , infinity
+  , negativeInfinity
   , isFinite
+  , minValue
+  , maxValue
   ) where
 
 import Data.Function.Uncurried (Fn4, runFn4)
 import Data.Maybe (Maybe(..))
+
+-- | The `Number` value for the magnitude of the difference between 1 and
+-- | the smallest value greater than 1 that is representable as a 
+-- | `Number` value, which is approximately 
+-- | 2.2204460492503130808472633361816 × 10⁻¹⁶
+foreign import epsilon :: Number
 
 -- | Not a number (NaN)
 foreign import nan :: Number
@@ -16,8 +26,11 @@ foreign import nan :: Number
 -- | Test whether a number is NaN
 foreign import isNaN :: Number -> Boolean
 
--- | Positive infinity
+-- | Positive infinity, +∞𝔽
 foreign import infinity :: Number
+
+-- | Negative inifinity, -∞𝔽
+foreign import negativeInfinity :: Number
 
 -- | Test whether a number is finite
 foreign import isFinite :: Number -> Boolean
@@ -53,3 +66,11 @@ fromString :: String -> Maybe Number
 fromString str = runFn4 fromStringImpl str isFinite Just Nothing
 
 foreign import fromStringImpl :: Fn4 String (Number -> Boolean) (forall a. a -> Maybe a) (forall a. Maybe a) (Maybe Number)
+
+-- | The largest positive finite value of the `Number` type, which is 
+-- | approximately 1.7976931348623157 × 10³⁰⁸
+foreign import maxValue :: Number
+
+-- | The smallest positive value of the `Number` type, which is 
+-- | approximately 5 × 10⁻³²⁴
+foreign import minValue :: Number


### PR DESCRIPTION
**Description of the change**

No pun intended, a number of properties are missing from JavaScript’s
`Number` as seen here: https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.epsilon

This includes: `EPSILON`, `NEGATIVE_INFINITY`, `MAX_VALUE`, and
`MIN_VALUE`.

I have a current use case for `MAX_VALUE`.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
