### PR TITLE
Add constants epsilon, minPosNumber and maxNumber

### DIFF
--- a/src/Data/Number.purs
+++ b/src/Data/Number.purs
@@ -1,10 +1,14 @@
--- | Functions for working with PureScripts builtin `Number` type.
+-- | Functions for working with PureScript's builtin `Number` type. A `Number`
+-- | is a double precision floating point number (IEEE 754 binary64).
 module Data.Number
   ( fromString
   , nan
   , isNaN
   , infinity
   , isFinite
+  , epsilon
+  , minPosNumber
+  , maxNumber
   , abs
   , acos
   , asin
@@ -81,6 +85,34 @@ foreign import infinity :: Number
 -- | false
 -- | ```
 foreign import isFinite :: Number -> Boolean
+
+-- | Machine epsilon according to the "widespread variant definition". That is
+-- | the difference between 1.0 and the next larger `Number`.
+-- | ```purs
+-- | > epsilon == 2.0 `pow` (-52.0)
+-- | true
+-- | ```
+epsilon :: Number
+epsilon = 2.220446049250313e-16
+
+-- | The smallest positive `Number`.
+-- | ```purs
+-- | > minNumber == 2.0 `pow` (-1074.0)
+-- | true
+-- |
+-- | > sign minNumber
+-- | 1.0
+-- | ```
+minPosNumber :: Number
+minPosNumber = 5e-324
+
+-- | The largest finite `Number`.
+-- | ```
+-- | > maxNumber == (2.0 `pow` 1023.0) * (1.0 + (1.0 - 2.0 `pow` (-52.0)))
+-- | true
+-- | ```
+maxNumber :: Number
+maxNumber = 1.7976931348623157e+308
 
 -- | Attempt to parse a `Number` using JavaScripts `parseFloat`. Returns
 -- | `Nothing` if the parse fails or if the result is not a finite number.

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -3,7 +3,7 @@ module Test.Main where
 import Prelude
 
 import Data.Maybe (Maybe(..), fromMaybe)
-import Data.Number ((%), abs, acos, asin, atan, atan2, ceil, cos, exp, floor, fromString, infinity, isFinite, isNaN, ln10, ln2, log10e, log2e, nan, pi, pow, round, sign, sin, sqrt, sqrt1_2, sqrt2, tan, tau, trunc)
+import Data.Number ((%), abs, acos, asin, atan, atan2, ceil, cos, epsilon, exp, floor, fromString, infinity, isFinite, isNaN, ln10, ln2, log10e, log2e, minPosNumber, maxNumber, nan, pi, pow, round, sign, sin, sqrt, sqrt1_2, sqrt2, tan, tau, trunc)
 import Data.Number (log) as Num
 import Data.Number.Approximate (Fraction(..), Tolerance(..), eqAbsolute, eqRelative, (≅), (≇))
 import Data.Number.Format (precision, fixed, exponential, toStringWith, toString)
@@ -41,6 +41,18 @@ globalsTestCode = do
 
   log "isFinite 0.0"
   assert $ isFinite 0.0
+
+  log "epsilon equals 2^-52"
+  assert $ epsilon == 2.0 `pow` (-52.0)
+
+  log "minPosNumber equals 2^-1074"
+  assert $ minPosNumber == 2.0 `pow` (-1074.0)
+
+  log "The sign of minPosNumber is 1.0"
+  assert $ sign minPosNumber == 1.0
+
+  log "maxNumber equals 2^1023 * (1 + (1 - 2^-52))"
+  assert $ maxNumber == (2.0 `pow` 1023.0) * (1.0 + (1.0 - 2.0 `pow` (-52.0)))
 
 -- Test code originally in this repo before parts of deprecated
 -- `purescript-globals` repo was moved to this repo.


### PR DESCRIPTION
Add constants: epsilon, minPosNumber and maxNumber as explicit values without any foreign imports. The values are the same value as the Javascript Number object properties EPSILON, MIN_VALUE and MAX_VALUE.

Closes issue #23 and replaces PR #19. Differences to PR #19:
- Values are explicit rather than imported from the Javascript Number object
- The value NEGATIVE_INFINITY is not implemented, since `-infinity` works just fine

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [X] Linked any existing issues or proposals that this pull request should close
- [X] Updated or added relevant documentation
- [X] Added a test for the contribution (if applicable)
