### PR TITLE
Fix `toStringWith` tests for `Fixed`

### DIFF
--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -136,11 +136,11 @@ numbersTestCode = do
     }
   assertEqual
     { expected: "3"
-    , actual: toStringWith (precision 0) pi
+    , actual: toStringWith (fixed 0) pi
     }
   assertEqual
     { expected: "3"
-    , actual: toStringWith (precision (-3)) pi
+    , actual: toStringWith (fixed (-3)) pi
     }
   assertEqual
     { expected: "1234.5"


### PR DESCRIPTION
The `toStringWith` tests for the `Fixed` case are not all using `fixed`.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
